### PR TITLE
Add form method overwite tests

### DIFF
--- a/tests/src/main/java/jakarta/mvc/tck/Sections.java
+++ b/tests/src/main/java/jakarta/mvc/tck/Sections.java
@@ -67,4 +67,8 @@ public class Sections {
     public static final String I18N_RESOLVING_ALGORITHM = "i18n_resolving_algorithm";
     public static final String I18N_DEFAULT_RESOLVER = "i18n_default_resolver";
 
+    /*
+     * Chapter: Form method overwrite
+     */
+    public static final String FORM_METHOD_OVERWRITE_ALGORITHM = "form_method_overwrite_resolving_algorithm";
 }

--- a/tests/src/main/java/jakarta/mvc/tck/tests/form/AbstractFormMethodOverwriteTest.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/form/AbstractFormMethodOverwriteTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package jakarta.mvc.tck.tests.form;
 
 import java.io.IOException;

--- a/tests/src/main/java/jakarta/mvc/tck/tests/form/AbstractFormMethodOverwriteTest.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/form/AbstractFormMethodOverwriteTest.java
@@ -1,0 +1,34 @@
+package jakarta.mvc.tck.tests.form;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlHiddenInput;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+public abstract class AbstractFormMethodOverwriteTest {
+    protected final HtmlPage getDefaultFormPage(final WebClient webClient, final URL baseUrl) throws java.io.IOException {
+        return getFormPageWithParam(webClient, baseUrl, "");
+    }
+
+    protected final HtmlPage getFormPageWithParam(final WebClient webClient, final URL baseUrl, String param) throws IOException {
+        if (param != null && !param.trim().isEmpty()) {
+            return webClient.getPage(baseUrl + "mvc/forms?hidden-field-setting=" + param);
+        }
+        return webClient.getPage(baseUrl + "mvc/forms");
+    }
+
+    protected final HtmlForm setHiddenMethodInForm(final HtmlPage page, final String method) {
+        final HtmlForm form = (HtmlForm) page.getElementById("form");
+        final HtmlHiddenInput hiddenMethod = (HtmlHiddenInput) page
+                .getElementById("hidden-method");
+        hiddenMethod.setValueAttribute(method);
+        return form;
+    }
+
+    protected final HtmlPage submit(final HtmlForm form) throws java.io.IOException {
+        return form.getInputByName("submit").click();
+    }
+}

--- a/tests/src/main/java/jakarta/mvc/tck/tests/form/CustomFormMethodFieldTest.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/form/CustomFormMethodFieldTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 - 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.mvc.tck.tests.form;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import jakarta.mvc.tck.Sections;
+import jakarta.mvc.tck.util.Archives;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+@SpecVersion(spec = "mvc", version = "2.1")
+public class CustomFormMethodFieldTest extends AbstractFormMethodOverwriteTest {
+
+    @ArquillianResource
+    protected URL baseUrl;
+
+    protected WebClient webClient;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return Archives.getMvcArchive(CustomFormMethodOverwriteFieldApplication.class)
+                .addClass(FormMethodOverwriteController.class)
+                .addView("form/form-with-renamed-hidden-field.jsp")
+                .addView("form/form-without-hidden-field.jsp")
+                .addView("form/result.jsp")
+                .build();
+    }
+
+    @Before
+    public void before() {
+        webClient = new WebClient();
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions().setRedirectEnabled(false);
+    }
+
+    @Test
+    @SpecAssertions({
+            @SpecAssertion(section = Sections.FORM_METHOD_OVERWRITE_ALGORITHM, id = "form-overwriter-algorithm")
+    })
+    public void processPUTIfFieldMatchesDifferentName() throws IOException {
+        final HtmlPage page = getFormPageWithParam(webClient, baseUrl, "renamed");
+
+        final HtmlForm form = setHiddenMethodInForm(page, "PUT");
+
+        final HtmlPage resultPage = submit(form);
+
+        assertEquals("PUT", resultPage.getElementById("invoked-method").getTextContent());
+    }
+}

--- a/tests/src/main/java/jakarta/mvc/tck/tests/form/CustomFormMethodFieldTest.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/form/CustomFormMethodFieldTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 - 2022 Eclipse Krazo committers and contributors
+ * Copyright (c) 2022 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/main/java/jakarta/mvc/tck/tests/form/CustomFormMethodOverwriteFieldApplication.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/form/CustomFormMethodOverwriteFieldApplication.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 - 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.mvc.tck.tests.form;
+
+import jakarta.mvc.form.FormMethodOverwriter;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@ApplicationPath("mvc")
+public class CustomFormMethodOverwriteFieldApplication extends Application {
+
+    @Override
+    public Map<String, Object> getProperties() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put(FormMethodOverwriter.HIDDEN_FIELD_NAME, "_other");
+        return properties;
+    }
+
+}

--- a/tests/src/main/java/jakarta/mvc/tck/tests/form/CustomFormMethodOverwriteFieldApplication.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/form/CustomFormMethodOverwriteFieldApplication.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 - 2022 Eclipse Krazo committers and contributors
+ * Copyright (c) 2022 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/main/java/jakarta/mvc/tck/tests/form/DefaultFormMethodOverwriteTest.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/form/DefaultFormMethodOverwriteTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 - 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.mvc.tck.tests.form;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import jakarta.mvc.tck.Sections;
+import jakarta.mvc.tck.util.Archives;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+@SpecVersion(spec = "mvc", version = "2.1")
+public class DefaultFormMethodOverwriteTest extends AbstractFormMethodOverwriteTest {
+
+    @ArquillianResource
+    protected URL baseUrl;
+
+    protected WebClient webClient;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return Archives.getMvcArchive()
+                .addClass(FormMethodOverwriteController.class)
+                .addView("form/form-with-hidden-field.jsp")
+                .addView("form/form-without-hidden-field.jsp")
+                .addView("form/result.jsp")
+                .build();
+    }
+
+    @Before
+    public void before() {
+        webClient = new WebClient();
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions().setRedirectEnabled(false);
+    }
+
+    @Test
+    @SpecAssertions({
+            @SpecAssertion(section = Sections.FORM_METHOD_OVERWRITE_ALGORITHM, id = "form-overwriter-algorithm")
+    })
+    public void processPOSTWithoutHiddenFormMethod() throws IOException {
+
+        final HtmlPage formPage = getFormPageWithParam(webClient, baseUrl, "none");
+        final HtmlForm form = (HtmlForm) formPage.getElementById("form");
+
+        final HtmlPage okPage = submit(form);
+
+        assertEquals("POST", okPage.getElementById("invoked-method").getTextContent());
+    }
+
+    @Test
+    @SpecAssertions({
+            @SpecAssertion(section = Sections.FORM_METHOD_OVERWRITE_ALGORITHM, id = "form-overwriter-algorithm")
+    })
+    public void processPUTWhenHiddenFormMethodIsPUT() throws IOException {
+        final HtmlPage page = getDefaultFormPage(webClient, baseUrl);
+
+        final HtmlForm form = setHiddenMethodInForm(page, "PUT");
+
+        final HtmlPage resultPage = submit(form);
+
+        assertEquals("PUT", resultPage.getElementById("invoked-method").getTextContent());
+    }
+
+    @Test
+    @SpecAssertions({
+            @SpecAssertion(section = Sections.FORM_METHOD_OVERWRITE_ALGORITHM, id = "form-overwriter-algorithm")
+    })
+    public void processPATCHWhenHiddenFormMethodIsPATCH() throws IOException {
+        final HtmlPage page = getDefaultFormPage(webClient, baseUrl);
+
+        final HtmlForm form = setHiddenMethodInForm(page, "PATCH");
+
+        final HtmlPage resultPage = submit(form);
+
+        assertEquals("PATCH", resultPage.getElementById("invoked-method").getTextContent());
+    }
+
+    @Test
+    @SpecAssertions({
+            @SpecAssertion(section = Sections.FORM_METHOD_OVERWRITE_ALGORITHM, id = "form-overwriter-algorithm")
+    })
+    public void processDELETEWhenHiddenFormMethodIsDelete() throws IOException {
+        final HtmlPage page = getDefaultFormPage(webClient, baseUrl);
+
+        final HtmlForm form = setHiddenMethodInForm(page, "DELETE");
+
+        final HtmlPage resultPage = submit(form);
+
+        assertEquals("DELETE", resultPage.getElementById("invoked-method").getTextContent());
+    }
+}

--- a/tests/src/main/java/jakarta/mvc/tck/tests/form/DefaultFormMethodOverwriteTest.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/form/DefaultFormMethodOverwriteTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 - 2022 Eclipse Krazo committers and contributors
+ * Copyright (c) 2022 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/main/java/jakarta/mvc/tck/tests/form/DisabledFormMethodOverwriteCustomApplication.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/form/DisabledFormMethodOverwriteCustomApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 - 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.mvc.tck.tests.form;
+
+import jakarta.mvc.form.FormMethodOverwriter;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@ApplicationPath("mvc")
+public class DisabledFormMethodOverwriteCustomApplication extends Application {
+
+    @Override
+    public Map<String, Object> getProperties() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put(FormMethodOverwriter.FORM_METHOD_OVERWRITE, FormMethodOverwriter.Options.DISABLED);
+        return properties;
+    }
+}

--- a/tests/src/main/java/jakarta/mvc/tck/tests/form/DisabledFormMethodOverwriteCustomApplication.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/form/DisabledFormMethodOverwriteCustomApplication.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 - 2022 Eclipse Krazo committers and contributors
+ * Copyright (c) 2022 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/main/java/jakarta/mvc/tck/tests/form/DisabledFormMethodOverwriteTest.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/form/DisabledFormMethodOverwriteTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 - 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.mvc.tck.tests.form;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import jakarta.mvc.tck.Sections;
+import jakarta.mvc.tck.util.Archives;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+@SpecVersion(spec = "mvc", version = "2.1")
+public class DisabledFormMethodOverwriteTest extends AbstractFormMethodOverwriteTest {
+
+    @ArquillianResource
+    protected URL baseUrl;
+
+    protected WebClient webClient;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return Archives.getMvcArchive(DisabledFormMethodOverwriteCustomApplication.class)
+                .addClass(FormMethodOverwriteController.class)
+                .addView("form/form-with-hidden-field.jsp")
+                .addView("form/result.jsp")
+                .build();
+    }
+
+    @Before
+    public void before() {
+        webClient = new WebClient();
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions().setRedirectEnabled(false);
+    }
+
+    @Test
+    @SpecAssertions({
+            @SpecAssertion(section = Sections.FORM_METHOD_OVERWRITE_ALGORITHM, id = "form-overwriter-algorithm")
+    })
+    public void processPOSTIgnoringHiddenFieldWhenFormMethodOverwriteIsDisabled() throws IOException {
+        final HtmlPage page = getDefaultFormPage(webClient, baseUrl);
+
+        final HtmlForm form = setHiddenMethodInForm(page, "PUT");
+
+        final HtmlPage resultPage = submit(form);
+
+        assertEquals("POST", resultPage.getElementById("invoked-method").getTextContent());
+
+    }
+}

--- a/tests/src/main/java/jakarta/mvc/tck/tests/form/DisabledFormMethodOverwriteTest.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/form/DisabledFormMethodOverwriteTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 - 2022 Eclipse Krazo committers and contributors
+ * Copyright (c) 2022 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/main/java/jakarta/mvc/tck/tests/form/FormMethodOverwriteController.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/form/FormMethodOverwriteController.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 - 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.mvc.tck.tests.form;
+
+import jakarta.inject.Inject;
+import jakarta.mvc.Controller;
+import jakarta.mvc.Models;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+
+@Path("forms")
+@Controller
+public class FormMethodOverwriteController {
+
+    @Inject
+    private Models models;
+
+    @GET
+    public String invokeGET(@QueryParam("hidden-field-setting") final String hiddenFieldSetting) {
+        if ("none".equals(hiddenFieldSetting)) {
+            return "form/form-without-hidden-field.jsp";
+        }
+        if ("renamed".equals(hiddenFieldSetting)) {
+            return "form/form-with-renamed-hidden-field.jsp";
+        }
+        return "form/form-with-hidden-field.jsp";
+    }
+
+    @POST
+    public String invokePOST() {
+        models.put("method", "POST");
+        return "form/result.jsp";
+    }
+
+    @PUT
+    public String invokePUT() {
+        models.put("method", "PUT");
+        return "form/result.jsp";
+    }
+
+    @PATCH
+    public String invokePATCH() {
+        models.put("method", "PATCH");
+        return "form/result.jsp";
+    }
+
+    @DELETE
+    public String invokeDELETE() {
+        models.put("method", "DELETE");
+        return "form/result.jsp";
+    }
+}

--- a/tests/src/main/java/jakarta/mvc/tck/tests/form/FormMethodOverwriteController.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/form/FormMethodOverwriteController.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 - 2022 Eclipse Krazo committers and contributors
+ * Copyright (c) 2022 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/main/resources/views/form/form-with-hidden-field.jsp
+++ b/tests/src/main/resources/views/form/form-with-hidden-field.jsp
@@ -1,0 +1,13 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<!doctype html>
+<html>
+<head>
+    <title>Forms Method</title>
+</head>
+<body>
+    <form id="form" action="forms" method="post">
+        <input id="hidden-method" name="_method" type="hidden">
+        <input type="submit" name="submit" value="Click here"/>
+    </form>
+</body>
+</html>

--- a/tests/src/main/resources/views/form/form-with-renamed-hidden-field.jsp
+++ b/tests/src/main/resources/views/form/form-with-renamed-hidden-field.jsp
@@ -1,0 +1,13 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<!doctype html>
+<html>
+<head>
+    <title>Forms Method</title>
+</head>
+<body>
+    <form id="form" action="forms" method="post">
+        <input id="hidden-method" name="_other" type="hidden" value="put">
+        <input type="submit" name="submit" value="Click here"/>
+    </form>
+</body>
+</html>

--- a/tests/src/main/resources/views/form/form-without-hidden-field.jsp
+++ b/tests/src/main/resources/views/form/form-without-hidden-field.jsp
@@ -1,0 +1,12 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<!doctype html>
+<html>
+<head>
+    <title>Forms Method</title>
+</head>
+<body>
+<form id="form" action="forms" method="post">
+    <input type="submit" name="submit" value="Click here"/>
+</form>
+</body>
+</html>

--- a/tests/src/main/resources/views/form/result.jsp
+++ b/tests/src/main/resources/views/form/result.jsp
@@ -1,0 +1,10 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<!doctype html>
+<html>
+<head>
+    <title>Forms Method</title>
+</head>
+<body>
+    <h1 id="invoked-method">${method}</h1>
+</body>
+</html>


### PR DESCRIPTION
This adds the tests for the 'form method overwrite'. After this PR is merged I'd create a milestone release to get a fixed version to use in Krazo.