### PR TITLE
Fixed CDI issues caused by protected methods

### DIFF
--- a/tests/src/main/java/jakarta/mvc/tck/tests/events/TraceManager.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/events/TraceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Christian Kaltepoth
+ * Copyright © 2018-2022 Christian Kaltepoth
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -33,7 +33,7 @@ public class TraceManager {
     @Inject
     private HttpServletRequest request;
 
-    void eventObserved(MvcEvent event) {
+    public void eventObserved(MvcEvent event) {
 
         Class<?> eventType = Arrays.stream(event.getClass().getInterfaces())
                 .filter(type -> type.getPackage().getName().startsWith("jakarta.mvc"))
@@ -44,15 +44,15 @@ public class TraceManager {
 
     }
 
-    void controllerExecuted() {
+    public void controllerExecuted() {
         logInternal("ControllerExecuted");
     }
 
-    void viewRendered() {
+    public void viewRendered() {
         logInternal("ViewRendered");
     }
 
-    TracedRequest getTracedRequest(String id) {
+    public TracedRequest getTracedRequest(String id) {
         return tracedRequests.get(id);
     }
 

--- a/tests/src/main/java/jakarta/mvc/tck/tests/i18n/algorithm/ResolverChainLogger.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/i18n/algorithm/ResolverChainLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Christian Kaltepoth
+ * Copyright © 2019-2022 Christian Kaltepoth
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,7 +27,7 @@ public class ResolverChainLogger {
 
     private List<String> classes = new ArrayList<>();
 
-    void log(Class<?> clazz) {
+    public void log(Class<?> clazz) {
         classes.add(clazz.getSimpleName());
     }
 


### PR DESCRIPTION
Our TCK started to fail with Wildfly 26.1.1 and Glassfish 7.0.0-SNAPSHOT. 

Example:

```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   MvcEventsTest.aroundControllerEvents:83 
Expected: <200>
     but: was <500>
[ERROR]   MvcEventsTest.aroundRenderView:122 
Expected: <200>
     but: was <500>
[ERROR]   MvcEventsTest.redirectEvent:166 
Expected: is not a 3xx status code
     but: was <500>
[ERROR]   I18nAlgorithmTest.continueChainForNullResult:96 
Expected: a string containing ",SecondLocaleResolver"
     but: was ""
[ERROR]   I18nAlgorithmTest.highestPrioExecutedFirst:82 
Expected: a string starting with "FirstLocaleResolver"
     but: was ""
```

I spent quite some to debug this issue. The result: For some reason, protected methods seem to cause issues with latest Weld releases. This manifests by `@Inject` being ignored (resulting in NPEs) and other weird stuff. Changing these methods to be public instead seems to fix all of these issues. So my proposal is to simply change the methods to be `public` which should actually be fine and works around these issues.

