### PR TITLE
Return Page as result in MvcEventstest#afterControllerWithError

### DIFF
--- a/tests/src/main/java/jakarta/mvc/tck/tests/events/MvcEventsTest.java
+++ b/tests/src/main/java/jakarta/mvc/tck/tests/events/MvcEventsTest.java
@@ -15,6 +15,7 @@
  */
 package jakarta.mvc.tck.tests.events;
 
+import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.TextPage;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
@@ -99,7 +100,8 @@ public class MvcEventsTest {
 
         String tid = UUID.randomUUID().toString();
 
-        HtmlPage mvcPage = webClient.getPage(baseUrl.toString() + "mvc/events/controller-error?tid=" + tid);
+        // It seems that e. g. WildFly handles error pages as plain text
+        Page mvcPage = webClient.getPage(baseUrl.toString() + "mvc/events/controller-error?tid=" + tid);
         assertThat(mvcPage.getWebResponse().getStatusCode(), equalTo(500));
 
         TextPage tracePage = webClient.getPage(baseUrl.toString() + "trace?tid=" + tid);


### PR DESCRIPTION
Because WildFly returns no HTML page as result of an unhandled HTTP
error code, this test fails on it. To ensure maximum compatibility to
all servers, this case will use the plain Page type provided by
HtmlUnit.

fixes: #34