### PR TITLE
Explicit packaging for BOM to avoid producing (empty) JAR

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>mvc-tck-bom</artifactId>
+    <packaging>pom</packaging>
     <name>Jakarta MVC TCK - BOM</name>
     <description>Technology Compatibility Kit for Jakarta MVC</description>
 


### PR DESCRIPTION
This also skips during build other jar-bound goals like:
```
[INFO] --- resources:3.3.1:resources (default-resources) @ mvc-tck-bom ---
...
[INFO] --- compiler:3.14.0:compile (default-compile) @ mvc-tck-bom ---
...
[INFO] --- resources:3.3.1:testResources (default-testResources) @ mvc-tck-bom ---
...
[INFO] --- compiler:3.14.0:testCompile (default-testCompile) @ mvc-tck-bom ---
...
[INFO] --- surefire:3.5.3:test (default-test) @ mvc-tck-bom ---
...
[INFO] --- jar:3.3.0:jar (default-jar) @ mvc-tck-bom ---
[WARNING] JAR will be empty - no content was marked for inclusion!
[INFO] Building jar: /home/piotr/projects/jakartaee/mvc-tck-work/bom/target/mvc-tck-bom-3.1.0-SNAPSHOT.jar
```